### PR TITLE
Add MemoryDatabase constructors to pass dictionary

### DIFF
--- a/Packages/UGF.Database/Runtime/Memory/MemoryDatabase.cs
+++ b/Packages/UGF.Database/Runtime/Memory/MemoryDatabase.cs
@@ -9,11 +9,54 @@ namespace UGF.Database.Runtime.Memory
     {
         public IReadOnlyDictionary<string, object> Values { get; }
 
-        private readonly Dictionary<string, object> m_values = new Dictionary<string, object>();
+        private readonly Dictionary<string, object> m_values;
 
         public MemoryDatabase()
         {
+            m_values ??= new Dictionary<string, object>();
+
             Values = new ReadOnlyDictionary<string, object>(m_values);
+        }
+
+        public MemoryDatabase(int capacity) : this(capacity, EqualityComparer<string>.Default)
+        {
+        }
+
+        public MemoryDatabase(int capacity, IEqualityComparer<string> comparer) : this()
+        {
+            if (capacity < 0) throw new ArgumentOutOfRangeException(nameof(capacity));
+            if (comparer == null) throw new ArgumentNullException(nameof(comparer));
+
+            m_values = new Dictionary<string, object>(capacity, comparer);
+        }
+
+        public MemoryDatabase(Dictionary<string, object> values) : this(values, EqualityComparer<string>.Default)
+        {
+        }
+
+        public MemoryDatabase(Dictionary<string, object> values, IEqualityComparer<string> comparer) : this()
+        {
+            if (values == null) throw new ArgumentNullException(nameof(values));
+            if (comparer == null) throw new ArgumentNullException(nameof(comparer));
+
+            m_values = new Dictionary<string, object>(comparer);
+
+            foreach (KeyValuePair<string, object> pair in values)
+            {
+                m_values.Add(pair.Key, pair.Value);
+            }
+        }
+
+        public MemoryDatabase(IDictionary<string, object> values) : this(values, EqualityComparer<string>.Default)
+        {
+        }
+
+        public MemoryDatabase(IDictionary<string, object> values, IEqualityComparer<string> comparer) : this()
+        {
+            if (values == null) throw new ArgumentNullException(nameof(values));
+            if (comparer == null) throw new ArgumentNullException(nameof(comparer));
+
+            m_values = new Dictionary<string, object>(values, comparer);
         }
 
         public Dictionary<string, object>.Enumerator GetEnumerator()

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "com.unity.ide.rider": "3.0.4",
-    "com.unity.test-framework": "1.1.22"
+    "com.unity.ide.rider": "3.0.7",
+    "com.unity.test-framework": "1.1.27"
   },
   "scopedRegistries": [
     {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -32,16 +32,16 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.4",
+      "version": "3.0.7",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.test-framework": "1.1.1"
+        "com.unity.ext.nunit": "1.0.6"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.22",
+      "version": "1.1.27",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.2.3f1
-m_EditorVersionWithRevision: 2020.2.3f1 (8ff31bc5bf5b)
+m_EditorVersion: 2020.3.9f1
+m_EditorVersionWithRevision: 2020.3.9f1 (108be757e447)


### PR DESCRIPTION
- Add constructor with initial _capacity_ and _comparer_.
- Add constructor with `Dictionary<string, object>` as values and _comparer_.
- Add constructor with `IDictionary<string, object>` as values and _comparer_.